### PR TITLE
Add backward compatibility for UMD require

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,12 @@
     "svg"
   ],
   "license": "BSD-3-Clause",
-  "main": "build/d3-area-chunked.js",
+  "module": "./index.js",
+  "main": "./index.js",
+  "exports": {
+    "umd": "./build/d3-area-chunked.min.js",
+    "default": "./index.js"
+  },
   "jsnext:main": "index",
   "homepage": "https://github.com/fvanwijk/d3-area-chunked",
   "repository": {


### PR DESCRIPTION
It wasn't working as expected. With these changes it should work (tested it). Also I added backward compatibility for when people use this package with require() instead of import